### PR TITLE
기본 페이지 생성 및 연결

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,20 +1,20 @@
 import React from "react";
-import "./App.css";
-import AdminFrame from "components/Layout/Frame";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+
+import "./App.css";
+import DashboardPage from "pages/Dashboard";
+import WorkListPage from "pages/WorkList";
+import WorkWritePage from "pages/WorkWrite";
+import PeopleListPage from "pages/PeopleList";
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route
-          path="/"
-          element={
-            <AdminFrame>
-              <div>aaa</div>
-            </AdminFrame>
-          }
-        ></Route>
+        <Route path="/" element={<DashboardPage />}></Route>
+        <Route path="/works" element={<WorkListPage />}></Route>
+        <Route path="/works/write" element={<WorkWritePage />}></Route>
+        <Route path="/people" element={<PeopleListPage />}></Route>
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/Layout/SideBar.js
+++ b/src/components/Layout/SideBar.js
@@ -1,27 +1,54 @@
 import React from "react";
+import { useLocation } from "react-router-dom";
 import { Navigation } from "@shopify/polaris";
-import { HomeMinor, OrdersMinor, ProductsMinor } from "@shopify/polaris-icons";
+import {
+  HomeMajor,
+  ListMajor,
+  FolderPlusMajor,
+  CustomersMajor,
+} from "@shopify/polaris-icons";
 
 export default function SideBarFrame() {
+  const location = useLocation();
+
   return (
-    <Navigation location="/">
+    <Navigation location={location.pathname}>
       <Navigation.Section
         items={[
           {
             url: "/",
-            label: "Home",
-            icon: HomeMinor,
+            label: "대시보드",
+            icon: HomeMajor,
+            exactMatch: true,
+          },
+        ]}
+      />
+      <Navigation.Section
+        separator
+        title="봉사 관리"
+        items={[
+          {
+            url: "/works",
+            label: "봉사 목록",
+            icon: ListMajor,
+            exactMatch: true,
           },
           {
-            url: "/path/to/place",
-            label: "Orders",
-            icon: OrdersMinor,
-            badge: "15",
+            url: "/works/write",
+            label: "봉사 추가",
+            icon: FolderPlusMajor,
+            exactMatch: true,
           },
+        ]}
+      />
+      <Navigation.Section
+        separator
+        title="대원 관리"
+        items={[
           {
-            url: "/path/to/place",
-            label: "Products",
-            icon: ProductsMinor,
+            url: "/people",
+            label: "대원 목록",
+            icon: CustomersMajor,
           },
         ]}
       />

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -1,0 +1,12 @@
+import React from "react";
+import AdminFrame from "components/Layout/Frame";
+
+const DashboardPage = () => {
+  return (
+    <AdminFrame>
+      <div>DashboardPage</div>
+    </AdminFrame>
+  );
+};
+
+export default DashboardPage;

--- a/src/pages/PeopleList.js
+++ b/src/pages/PeopleList.js
@@ -1,0 +1,12 @@
+import React from "react";
+import AdminFrame from "components/Layout/Frame";
+
+const PeopleListPage = () => {
+  return (
+    <AdminFrame>
+      <div>PeopleListPage</div>
+    </AdminFrame>
+  );
+};
+
+export default PeopleListPage;

--- a/src/pages/WorkList.js
+++ b/src/pages/WorkList.js
@@ -1,0 +1,12 @@
+import React from "react";
+import AdminFrame from "components/Layout/Frame";
+
+const WorkListPage = () => {
+  return (
+    <AdminFrame>
+      <div>WorkListPage</div>
+    </AdminFrame>
+  );
+};
+
+export default WorkListPage;

--- a/src/pages/WorkWrite.js
+++ b/src/pages/WorkWrite.js
@@ -1,0 +1,12 @@
+import React from "react";
+import AdminFrame from "components/Layout/Frame";
+
+const WorkWritePage = () => {
+  return (
+    <AdminFrame>
+      <div>WorkWritePage</div>
+    </AdminFrame>
+  );
+};
+
+export default WorkWritePage;


### PR DESCRIPTION
수정
- 기본 페이지 추가
  - 대시보드, 봉사 목록, 봉사 추가, 대원 목록
- 각 페이지 라우터 연결
- 사이드바에 네비게이션 추가

참고
- 노션 태스크: https://www.notion.so/b20f2fb29c2d4beb86dbdc9922fae6a8?v=1d118b8b9b424d07af46f47e0440139a&p=0330e500b29f4eeeb8f0a5f319160ddb