### PR TITLE
사이드바 네비게이션 로직 수정

### DIFF
--- a/src/components/Layout/Frame.js
+++ b/src/components/Layout/Frame.js
@@ -1,5 +1,5 @@
 import React from "react";
-
+import { Link as ReactRouterLink } from "react-router-dom";
 import en from "@shopify/polaris/locales/en.json";
 import { AppProvider, Frame } from "@shopify/polaris";
 
@@ -15,8 +15,16 @@ export default function AdminFrame({ title, children }) {
     accessibilityLabel: "Jaded Pixel",
   };
 
+  const Link = ({ children, url = "", ...rest }) => {
+    return (
+      <ReactRouterLink to={url} {...rest}>
+        {children}
+      </ReactRouterLink>
+    );
+  };
+
   return (
-    <AppProvider i18n={en}>
+    <AppProvider i18n={en} linkComponent={Link}>
       <Frame logo={logo} topBar={<TopBarFrame />} navigation={<SideBarFrame />}>
         {children}
       </Frame>


### PR DESCRIPTION
수정
- 사이드바 네비게이션 로직 수정
  - a태그 처럼 새로고침으로 만들어지던 페이지 이동을 react-router-dom의 link 사용

참고
- 노션 태스크: https://www.notion.so/b20f2fb29c2d4beb86dbdc9922fae6a8?v=1d118b8b9b424d07af46f47e0440139a&p=38a63be3fcb9465484daafdb5c8b2b12